### PR TITLE
Add commonjs extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This module exports three attributes:
 #### JavaScript
 
 - js
+- [cjs](https://nodejs.org/api/esm.html#esm_ecmascript_modules)
 - [mjs](https://nodejs.org/api/esm.html#esm_ecmascript_modules)
 
 #### [IcedCoffeeScript](http://maxtaco.github.io/coffee-script/)

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@
 
 var codeExtensions = [
   'js', // built-in
+  'cjs', // https://nodejs.org/api/esm.html#esm_enabling
   'mjs', // https://nodejs.org/api/esm.html#esm_enabling
   'iced', // http://maxtaco.github.io/coffee-script/
   'liticed', // http://maxtaco.github.io/coffee-script/ (literate iced)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "common-js-file-extensions",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-js-file-extensions",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Common JavaScript File Extensions",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When package (or directories) are marked by package.json with `"type": "module"`, an explicit way to declare commonjs files is by using the file extension "cjs", similarly to the use of "mjs" file extension for commonjs type modules (which is the default ATM)